### PR TITLE
Add unversioned redirect to API docs

### DIFF
--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,0 +1,5 @@
+---
+layout: redirect
+permalink: /docs/api/
+redirect: /docs/v5.10.0/api
+---


### PR DESCRIPTION
Added a redirect from http://project-osrm.org/docs/api/ to the latest API documentation, currently http://project-osrm.org/docs/v5.10.0/api/. This redirect will need to be updated every time a new release is published.

/cc @daniel-j-h @danpat