### PR TITLE
Replace API documentation redirect with redirect-from

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,2 @@
+plugins:
+  - jekyll-redirect-from

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -1,5 +1,0 @@
----
-layout: redirect
-permalink: /docs/api/
-redirect: /docs/v5.10.0/api
----

--- a/docs/v5.10.0/api/index.html
+++ b/docs/v5.10.0/api/index.html
@@ -1,3 +1,6 @@
+---
+redirect_from: "/docs/api/"
+---
 <!DOCTYPE html>
 <html>
   <head>


### PR DESCRIPTION
#10 didn’t work, because it depends on a publishing tool that isn’t present on GitHub Pages. Instead, this PR uses a [whitelisted jekyll plugin](https://help.github.com/articles/redirects-on-github-pages/) to create the redirect. I’ve tested this locally to verify that it works with jekyll.

Each time a new release is published, `redirect_from` must be removed from the old version and added to the new version. Alternatively, we could have index.html be [a simple HTML page](https://github.com/mapbox/mapbox-navigation-ios/blob/3e35224ada22d7fb57a66ad3dd157610d958352f/directions/index.html) with a meta redirect. @danpat @daniel-j-h, which approach would you prefer?