### PR TITLE
Restores map.project-osrm.org as the demo site

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,7 +19,7 @@
         <div class='col6 margin3 pad4y clearfix'>
           <div class='pad2y title '>Modern C++ routing engine for shortest paths in road networks.</div>
           <div class='center'>
-            <a href='https://www.mapbox.com/get-directions/'><input type='button' class='button' value='VIEW DEMO' name='' /></a> <a href='docs/v5.10.0/api'><input type='button' class='button' value="DOCUMENTATION" name='' /></a>
+            <a href='http://map.project-osrm.org/'><input type='button' class='button' value='VIEW DEMO' name='' /></a> <a href='docs/v5.10.0/api'><input type='button' class='button' value="DOCUMENTATION" name='' /></a>
             <p class='pad2x'><a class="github-button" href="https://github.com/Project-OSRM/osrm-backend/fork" data-icon="octicon-git-branch" data-style="mega" data-count-href="/Project-OSRM/osrm-backend/network" data-count-api="/repos/Project-OSRM/osrm-backend#forks_count" data-count-aria-label="# forks on GitHub" aria-label="Fork Project-OSRM/osrm-backend on GitHub">Fork</a></p>
           </div>
         </div>


### PR DESCRIPTION
The `router.project-osrm.org` demoserver has been stabilized by deploying to the Mapbox production infrastructure.  This will add a bunch of reliability/monitoring, so switching the demo back to `osrm-frontend` again.