### PR TITLE
fix: remove invalid disallowScopes sequence from workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -14,7 +14,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           requireScope: false
-          disallowScopes: []
           types: |
             feat
             fix


### PR DESCRIPTION
Removes the `disallowScopes: []` line which caused a YAML validation error ("A sequence was not expected" at line 17). The `disallowScopes` input expects a multiline string, not a YAML flow sequence. Since no scopes are being disallowed, removing the line is equivalent.